### PR TITLE
Moved updating browser history into separate function

### DIFF
--- a/modules/router5.js
+++ b/modules/router5.js
@@ -127,7 +127,7 @@ class Router5 {
                     this.navigate(opts.defaultRoute, opts.defaultParams, {reload: true, replace: true})
                 }
             } else {
-                browser[newState ? 'pushState' : 'replaceState'](toState, '', this.buildUrl(toState.name, toState.params))
+                this.updateBrowserState(toState, this.buildUrl(toState.name, toState.params), newState)
             }
         })
     }
@@ -604,9 +604,20 @@ class Router5 {
                 return
             }
 
-            browser[opts.replace ? 'replaceState' : 'pushState'](this.lastStateAttempt, '', url)
+            this.updateBrowserState(this.lastStateAttempt, url, opts.replace)
             if (done) done(null, state)
         })
+    }
+
+    /**
+     * Update the browser history
+     * @param {Object}  stateObject     State object to be used
+     * @param {string}  url             Absolute url to be used
+     * @param {boolean} [replace=false] If replaceState or pushState should be used
+     * @param {string}  [title='']      The title to be used for history
+     */
+    updateBrowserState(stateObject, url, replace = false, title = '') {
+        browser[replace ? 'replaceState' : 'pushState'](stateObject, title, url);
     }
 }
 


### PR DESCRIPTION
While integrating router5 into an AngularJS application we had the issue, of infinite digests. The problem seems to occur when updating the history directly instead of using angulars `$location` service.

With this pull request we moved the actual updating logic into a separate function. This can be overloaded when needed with special use case dependent logic.