### PR TITLE
fix: don't typecast falsy path values to string

### DIFF
--- a/modules/router5.js
+++ b/modules/router5.js
@@ -396,7 +396,7 @@ class Router5 {
     _buildUrl(path) {
         return (this.options.base || '') +
             (this.options.useHash ? '#' + this.options.hashPrefix : '') +
-            path;
+            (path || '');
     }
 
     /**


### PR DESCRIPTION
Fixes case when url being generated as 'null' when route for the given name is not found.
