### PR TITLE
fix: onTransitionCancel() not get called in plugins

### DIFF
--- a/modules/core/navigation.js
+++ b/modules/core/navigation.js
@@ -112,7 +112,7 @@ export default function withNavigation(router) {
 
             if (err) {
                 if (err.code === errorCodes.TRANSITION_CANCELLED) {
-                    router.invokeEventListeners(constants.TRANSITION_CANCELLED, toState, fromState);
+                    router.invokeEventListeners(constants.TRANSITION_CANCEL, toState, fromState);
                 } else {
                     router.invokeEventListeners(constants.TRANSITION_ERROR, toState, fromState, err);
                 }


### PR DESCRIPTION
Use a proper constant name `TRANSITION_CANCEL` instead of `TRANSITION_CANCELLED`