### PR TITLE
Route forwarding

### DIFF
--- a/packages/router5/index.d.ts
+++ b/packages/router5/index.d.ts
@@ -85,6 +85,7 @@ declare module "router5" {
 
     // navigation
     cancel(): Router;
+    forward(fromRouteName: string, toRouteName: string): Router;
     navigate(routeName: string, routeParams?: object, options?: NavigationOptions, done?: Function): Function;
     navigateToDefault(options?: NavigationOptions, done?: Function): Function;
 

--- a/packages/router5/modules/core/navigation.js
+++ b/packages/router5/modules/core/navigation.js
@@ -5,11 +5,13 @@ const noop = function() {};
 
 export default function withNavigation(router) {
     let cancelCurrentTransition;
+    const forwardMap = {};
 
     router.navigate = navigate;
     router.navigateToDefault = navigateToDefault;
     router.transitionToState = transitionToState;
     router.cancel = cancel;
+    router.forward = forward;
 
     /**
      * Cancel the current transition if there is one
@@ -25,6 +27,18 @@ export default function withNavigation(router) {
     }
 
     /**
+     * Forward a route to another route, when calling navigate.
+     * Route parameters for the two routes should match to avoid issues.
+     * @param  {String}   fromRoute      The route name
+     * @param  {String}   toRoute  The route params
+     */
+    function forward(fromRoute, toRoute) {
+        forwardMap[fromRoute] = toRoute;
+
+        return router;
+    }
+
+    /**
      * Navigate to a route
      * @param  {String}   routeName      The route name
      * @param  {Object}   [routeParams]  The route params
@@ -33,7 +47,7 @@ export default function withNavigation(router) {
      * @return {Function}                A cancel function
      */
     function navigate(...args) {
-        const name = args[0];
+        const name = forwardMap[args[0]] || args[0];
         const lastArg = args[args.length - 1];
         const done = typeof lastArg === 'function' ? lastArg : noop;
         const params = typeof args[1] === 'object' ? args[1] : {};

--- a/packages/router5/modules/create-router.js
+++ b/packages/router5/modules/create-router.js
@@ -98,15 +98,17 @@ function createRouter(routes, opts = {}, deps = {}) {
 
     const rootNode = routes instanceof RouteNode
         ? routes
-        : new RouteNode('', '', routes, addCanActivate);
+        : new RouteNode('', '', routes, onRouteAdded);
 
     router.rootNode = rootNode;
 
     return router;
 
-    function addCanActivate(route) {
+    function onRouteAdded(route) {
         if (route.canActivate)
             router.canActivate(route.name, route.canActivate);
+
+        if (route.forwardTo) router.forward(route.name, route.forwardTo);
     }
 
     /**
@@ -231,7 +233,7 @@ function createRouter(routes, opts = {}, deps = {}) {
      * @return {Object}       The router instance
      */
     function add(routes) {
-        rootNode.add(routes, addCanActivate);
+        rootNode.add(routes, onRouteAdded);
         return router;
     }
 

--- a/packages/router5/test/core/navigation.js
+++ b/packages/router5/test/core/navigation.js
@@ -172,4 +172,14 @@ describe('core/navigation', function() {
             done();
         });
     });
+
+    it('should forward a route to another route', done => {
+        router.forward('profile', 'profile.me');
+
+        router.navigate('profile', (err, state) => {
+            expect(state.name).to.equal('profile.me');
+            router.forward('profile', undefined);
+            done();
+        });
+    });
 });


### PR DESCRIPTION
Add route forwarding: when navigating to route A, route B will be hit instead. This is useful for defaulting to a child route, or aliasing a route with different paths.

Routes can be defined with a new `forwardTo` property, or forwarding can be configured with `router.forward(fromRouteName, toRouteName)`.

```js
const routes = [
   {
      name: 'admin',
      path: '/admin',
      forwardTo: 'admin.home'
   },
   {
      name: 'admin.home',
      path: '/'
   },
];

const router = createRouter(routes);
```

```js
router.forward('admin', 'admin.home');
```