### PR TITLE
Allow route forwarding on router start

### DIFF
--- a/packages/router5/modules/core/navigation.js
+++ b/packages/router5/modules/core/navigation.js
@@ -5,8 +5,8 @@ const noop = function() {};
 
 export default function withNavigation(router) {
     let cancelCurrentTransition;
-    const forwardMap = {};
 
+    router.forwardMap = {};
     router.navigate = navigate;
     router.navigateToDefault = navigateToDefault;
     router.transitionToState = transitionToState;
@@ -33,7 +33,7 @@ export default function withNavigation(router) {
      * @param  {String}   toRoute  The route params
      */
     function forward(fromRoute, toRoute) {
-        forwardMap[fromRoute] = toRoute;
+        router.forwardMap[fromRoute] = toRoute;
 
         return router;
     }
@@ -47,7 +47,7 @@ export default function withNavigation(router) {
      * @return {Function}                A cancel function
      */
     function navigate(...args) {
-        const name = forwardMap[args[0]] || args[0];
+        const name = router.forwardMap[args[0]] || args[0];
         const lastArg = args[args.length - 1];
         const done = typeof lastArg === 'function' ? lastArg : noop;
         const params = typeof args[1] === 'object' ? args[1] : {};

--- a/packages/router5/modules/core/utils.js
+++ b/packages/router5/modules/core/utils.js
@@ -130,8 +130,15 @@ export default function withUtils(router) {
             const builtPath = options.useTrailingSlash === undefined
                 ? path
                 : router.buildPath(name, params);
+            const routeName = router.forwardMap[name] || name;
 
-            return router.makeState(name, params, builtPath, _meta, source);
+            return router.makeState(
+                routeName,
+                params,
+                builtPath,
+                _meta,
+                source
+            );
         }
 
         return null;


### PR DESCRIPTION
`forwardTo` is ignored on router start, this fixes it.