### PR TITLE
Correct state comparison (areStatesEqual) with non-strict query parameters

### DIFF
--- a/packages/router5/modules/core/utils.js
+++ b/packages/router5/modules/core/utils.js
@@ -56,16 +56,15 @@ export default function withUtils(router) {
         const getUrlParams = name =>
             router.rootNode
                 .getSegmentsByName(name)
-                .map(
-                    segment =>
-                        segment.parser[
-                            ignoreQueryParams ? 'urlParams' : 'params'
-                        ]
-                )
+                .map(segment => segment.parser['urlParams'])
                 .reduce((params, p) => params.concat(p), []);
 
-        const state1Params = getUrlParams(state1.name);
-        const state2Params = getUrlParams(state2.name);
+        const state1Params = ignoreQueryParams
+            ? getUrlParams(state1.name)
+            : Object.keys(state1.params);
+        const state2Params = ignoreQueryParams
+            ? getUrlParams(state2.name)
+            : Object.keys(state2.params);
 
         return (
             state1Params.length === state2Params.length &&

--- a/packages/router5/modules/plugins/browser/index.js
+++ b/packages/router5/modules/plugins/browser/index.js
@@ -146,13 +146,14 @@ function browserPluginFactory(opts = {}, browser = safeBrowser) {
 
         function onTransitionSuccess(toState, fromState, opts) {
             const historyState = browser.getState();
-            const replace =
-                opts.replace ||
-                (fromState &&
-                    router.areStatesEqual(toState, fromState, false)) ||
-                (opts.reload &&
-                    historyState &&
-                    router.areStatesEqual(toState, historyState, false));
+            const hasState =
+                historyState &&
+                historyState.meta &&
+                historyState.name &&
+                historyState.params;
+            const statesAreEqual =
+                fromState && router.areStatesEqual(fromState, toState, false);
+            const replace = opts.replace || !hasState || statesAreEqual;
             let url = router.buildUrl(toState.name, toState.params);
             if (
                 fromState === null &&


### PR DESCRIPTION
`router.areStatesEqual` gives a false positive when `strictQueryParams` is `false` and extra query params are provided.

Fixes #133 