### PR TITLE
Use console.groupCollapsed() in the logger plugin, where available.

### DIFF
--- a/packages/router5/modules/plugins/logger/index.js
+++ b/packages/router5/modules/plugins/logger/index.js
@@ -3,13 +3,18 @@
 const noop = () => {};
 
 function loggerPlugin() {
-    const supportsGroups = console.group && console.groupEnd;
-    const startGroup = supportsGroups
-        ? () => console.group('Router transition')
-        : noop;
-    const endGroup = supportsGroups
-        ? () => console.groupEnd('Router transition')
-        : noop;
+    let startGroup, endGroup;
+
+    if (console.groupCollapsed) {
+        startGroup = label => console.groupCollapsed(label);
+        endGroup = () => console.groupEnd();
+    } else if (console.group) {
+        startGroup = label => console.group(label);
+        endGroup = () => console.groupEnd();
+    } else {
+        startGroup = noop;
+        endGroup = noop;
+    }
 
     console.info('Router started');
 
@@ -19,7 +24,7 @@ function loggerPlugin() {
         },
         onTransitionStart(toState, fromState) {
             endGroup();
-            startGroup();
+            startGroup('Router transition');
             console.log('Transition started from state');
             console.log(fromState);
             console.log('To state');


### PR DESCRIPTION
This PR makes use of [console.groupCollapsed](https://developer.mozilla.org/en-US/docs/Web/API/Console/groupCollapsed) in the logger plugin, where available.

This is a quality of life improvement for those using the logger plugin in conjunction with other systems that log to the console, reducing noise from the router5 logger without losing any detail.

Unfortunately there does not seem to be an existing logger plugin test suite, so I was unable to submit this PR with tests.