### PR TITLE
Router plugin buildUrl should return null for undefined routes

### DIFF
--- a/packages/router5/modules/plugins/browser/utils.js
+++ b/packages/router5/modules/plugins/browser/utils.js
@@ -8,6 +8,8 @@ export default function withUtils(router, options) {
         const prefix = options.useHash ? `#${options.hashPrefix}` : '';
         const path = router.buildPath(route, params);
 
+        if (path === null) return null;
+
         return base + prefix + path;
     }
 

--- a/packages/router5/test/plugins/browser.js
+++ b/packages/router5/test/plugins/browser.js
@@ -155,6 +155,7 @@ function test(useHash) {
                     path: '/route-not-found'
                 })
             ).to.equal(prefix + '/route-not-found');
+            expect(router.buildUrl('undefined', {})).to.equal(null);
         });
     });
 }


### PR DESCRIPTION
This PR fixes a bug in the browser plugin's `buildUrl()` function.

Currently, if you use `buildUrl()` with an undefined route name, you get the "base" URL with the string `null` appended to the end, like so (assuming base path `http://localhost:8080/basepath`):

    http://localhost:8080/basepathnull

This PR changes the behavior to match that of `buildPath()`, which is to simply return `null`.

Can I also ask - is there an equivalent to `buildPath()` that knows about the base path?