### PR TITLE
Add type definition for `persistentParamsPlugin`

### DIFF
--- a/packages/router5/index.d.ts
+++ b/packages/router5/index.d.ts
@@ -418,3 +418,13 @@ declare module "router5/plugins/listeners" {
   var listenersPlugin: (options?: ListenersPluginOptions) => PluginFactory;
   export default listenersPlugin;
 }
+
+declare module "router5/plugins/persistentParams" {
+  import { PluginFactory } from "router5";
+  // persistentParamsPlugin takes a single argument which can be:
+  //   - A list of string (parameter names to persist), or
+  //   - A map of key value pairs (keys being the params to persist, values their initial value)
+  type PersistentParamsPluginParams = string[] | object;
+  var persistentParamsPlugin: (params?: PersistentParamsPluginParams) => PluginFactory;
+  export default persistentParamsPlugin;
+}


### PR DESCRIPTION
This adds a type definition for `persistentParamsPlugin`. From @troch:

> persistentParamsPlugin isn't defined, that's right. PR welcome! Add it at the end of the definition file, after other plugins (browser plugin, listeners plugin). Source is here: https://github.com/router5/router5/blob/master/packages/router5/modules/plugins/persistentParams/index.js, it takes a single argument which can be:
> 
> A list of string (parameter names to persist)
> A map of key value pairs (keys being the params to persist, values their initial value)
