### PR TITLE
Add typings for rxjs-router5

### DIFF
--- a/packages/rxjs-router5/index.d.ts
+++ b/packages/rxjs-router5/index.d.ts
@@ -1,0 +1,11 @@
+declare module "rxjs-router5" {
+    import * as Rx from "rxjs";
+    import { State, Router } from "router5";
+    interface RouterObservables {
+        route$: Rx.Observable<State>;
+        routeNode: () => Rx.Observable<State>;
+        transitionError$: Rx.Observable<any>;
+        transitionRoute$: Rx.Observable<State>;
+    }
+    export default function createObservables(router: Router): RouterObservables;
+}

--- a/packages/rxjs-router5/index.d.ts
+++ b/packages/rxjs-router5/index.d.ts
@@ -2,9 +2,20 @@ declare module "rxjs-router5" {
     import * as Rx from "rxjs";
     import { State, Router } from "router5";
     interface RouterObservables {
+        /// route$: an observable of your application route
         route$: Rx.Observable<State>;
-        routeNode: () => Rx.Observable<State>;
+
+        /** 
+         * @param nodeName the name of a node
+         * @returns an observable of route updates for the specified node.
+         * See understanding router5: http://router5.github.io/docs/understanding-router5.html.
+         */
+        routeNode: (nodeName: string) => Rx.Observable<State>;
+
+        /// an observable of transition errors
         transitionError$: Rx.Observable<any>;
+        
+        /// an observable of the currently transitioning route
         transitionRoute$: Rx.Observable<State>;
     }
     export default function createObservables(router: Router): RouterObservables;

--- a/packages/rxjs-router5/package.json
+++ b/packages/rxjs-router5/package.json
@@ -28,5 +28,6 @@
   "peerDependencies": {
     "router5": "^5.0.1",
     "rxjs": "^5.0.0-beta.11"
-  }
+  },
+  "typings": "./index.d.ts"
 }


### PR DESCRIPTION
These are proposed typings for `createObservables`, which provides rxjs observables for some router5 events. Comments appreciated on the correctness of the types and comments; it wasn't always obvious from the code what the correct types should be.

Also, it wasn't obvious how to test these typings. I did some ad-hoc testing by copying them to a separate repo, but setting up a test within this repo wasn't obvious.