### PR TITLE
Update route-node to v1.9.0

### DIFF
--- a/packages/router5/package.json
+++ b/packages/router5/package.json
@@ -27,8 +27,8 @@
   },
   "homepage": "http://router5.github.io",
   "dependencies": {
-    "route-node": "1.8.5",
-    "router5-transition-path": "^5.0.0"
+    "route-node": "1.9.0",
+    "router5-transition-path": "5.0.0"
   },
   "typings": "./index.d.ts"
 }

--- a/packages/router5/yarn.lock
+++ b/packages/router5/yarn.lock
@@ -8,9 +8,9 @@ path-parser@2.0.2:
   dependencies:
     search-params "~1.3.0"
 
-route-node@1.8.5:
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/route-node/-/route-node-1.8.5.tgz#184181147e53049b00f7e4d88115c960d4e1b88a"
+route-node@1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/route-node/-/route-node-1.9.0.tgz#e41b1ceae98f4ce7a39187b6015a1d4758f9103c"
   dependencies:
     path-parser "2.0.2"
     search-params "~1.3.0"


### PR DESCRIPTION
Update route-node to v1.9.0 to allow pseudo-pathless nested routes (`'/'`)

#200