### PR TITLE
Remove `?` from middleware `done` arg to avoid checking it's presence

### DIFF
--- a/packages/router5/index.d.ts
+++ b/packages/router5/index.d.ts
@@ -56,7 +56,7 @@ declare module "router5" {
   }
 
   export interface Middleware {
-    (toState: State, fromState: State, done?: Function): any;
+    (toState: State, fromState: State, done: Function): any;
   }
 
   export interface MiddlewareFactory {


### PR DESCRIPTION
If I understand correctly, the question mark was there with intention to use it in both variants:

```javascript
// sync
router => (toState, fromState) => true
// or async
router => (toState, fromState, done) => {
  setTimeout(() => done(), 500)
}
```

But in reality it's not helping in any way, because it's treated not like "we can define function with this argument or not", but instead "when we're called it can be undefined".

And AFAIK if we got that arg defined in middleware, then it will always be defined and act asynchronously. Is It correct?