### PR TITLE
fix(ts): don't swallow types in HOCs

### DIFF
--- a/packages/react-router5/index.d.ts
+++ b/packages/react-router5/index.d.ts
@@ -1,6 +1,14 @@
 declare module "react-router5" {
-    import { ComponentClass, MouseEventHandler, StatelessComponent, HTMLAttributes } from 'react';
+    import { ComponentClass, ComponentType, MouseEventHandler, HTMLAttributes } from 'react';
     import { Router, Route, State } from 'router5';
+
+    type Diff<T extends string, U extends string> = ({[P in T]: P} &
+        {[P in U]: never} & { [x: string]: never })[T]
+
+    type Omit<InputObject, Keys extends keyof InputObject> = Pick<
+        InputObject,
+        Diff<keyof InputObject, Keys>
+        >
 
     export interface RouterProviderProps {
         router: Router;
@@ -30,12 +38,13 @@ declare module "react-router5" {
         previousRoute: State;
     }>;
 
-    export function withRoute<
-        TProps extends InjectedRoute,
-            TComponent extends (ComponentClass<TProps> | StatelessComponent<TProps>)
-        >(
-            BaseComponent: TComponent
-        ): ComponentClass<TProps>;
+    export function withRoute<TProps extends InjectedRoute>(
+        BaseComponent: ComponentType<TProps>
+    ):
+        ComponentClass<Omit<
+        TProps,
+        keyof InjectedRoute
+        >>;
 
     export type InjectedRouterNode = Partial<{
         router: Router,
@@ -43,12 +52,11 @@ declare module "react-router5" {
         route: State,
     }>;
 
-    export function routerNode<
-        TProps extends InjectedRouterNode,
-            TComponent extends (ComponentClass<TProps> | StatelessComponent<TProps>)
-        >(
-            nodeName: string
-        ): (
-            RouteSegment: TComponent
-        ) => ComponentClass<TProps>;
+    export function routerNode<TProps extends InjectedRouterNode>(
+        nodeName: string
+    ): (RouteSegment: ComponentType<TProps>) =>
+            ComponentClass<Omit<
+            TProps,
+            keyof InjectedRouterNode
+            >>;
 }


### PR DESCRIPTION
Right now HOCs (`withRoute` and `routerNode`) swallow wrapped component prop types. So if we have props on that component and wrap it, prop types are gone. This PR fixes that behavior.