### PR TITLE
Add type definitions for router5-transition-path

### DIFF
--- a/packages/router5-transition-path/index.d.ts
+++ b/packages/router5-transition-path/index.d.ts
@@ -1,0 +1,15 @@
+declare module 'router5-transition-path' {
+    import { State } from 'router5'
+
+    export function nameToIDs(name: string): string[]
+
+    export interface TransitionPath {
+        intersection: string
+        toDeactivate: string[]
+        toActivate: string[]
+    }
+
+    function transitionPath(toState: State, fromState?: State): TransitionPath
+
+    export default transitionPath
+}

--- a/packages/router5-transition-path/test/main.js
+++ b/packages/router5-transition-path/test/main.js
@@ -1,5 +1,6 @@
 import transitionPath from '../modules'
 import { expect } from 'chai'
+import tt from 'typescript-definition-tester'
 
 describe('router5-transition-path', function() {
     it('should return a transition path with from null state', function() {
@@ -64,5 +65,16 @@ describe('router5-transition-path', function() {
                 { name: 'a.b.c.d', params: { p1: 1, p2: 2, p3: 3 }, meta }
             ).intersection
         ).to.equal('a.b.c')
+    })
+
+    describe('TypeScript definitions', function() {
+        it('should compile examples against index.d.ts', function(done) {
+            tt.compileDirectory(
+                `${__dirname}/typescript`,
+                filename => filename.match(/\.ts$/),
+                { lib: ['lib.es2015.d.ts'] },
+                () => done()
+            )
+        })
     })
 })

--- a/packages/router5-transition-path/test/typescript/index.ts
+++ b/packages/router5-transition-path/test/typescript/index.ts
@@ -1,0 +1,16 @@
+/// <reference path="../../../router5/index.d.ts" />
+/// <reference path="../../index.d.ts" />
+
+import transitionPath, {
+    nameToIDs,
+    TransitionPath
+} from 'router5-transition-path'
+
+const _ids: string[] = nameToIDs('a.b.c')
+
+let tp: TransitionPath
+tp = transitionPath(
+    { name: 'a.b.c', params: {}, path: '/a/b/c' },
+    { name: 'a.b.d', params: {}, path: '/a/b/d' }
+)
+tp = transitionPath({ name: 'a.b.c', params: {}, path: '/a/b/c' })

--- a/packages/router5/index.d.ts
+++ b/packages/router5/index.d.ts
@@ -28,9 +28,7 @@ declare module 'router5' {
         ActivationFnFactory as RouterActivationHandlerFactory
     } from 'router5/core/route-lifecycle'
     import loggerPlugin from 'router5/plugins/loggers'
-
-    // router5-transition-path
-    const transitionPath: (toState: State, fromState?: State) => any
+    import transitionPath from 'router5-transition-path'
 
     type DoneFn = (err?: any, state?: State) => void
 


### PR DESCRIPTION
Implements the `transitionPath` stub that was in router5's type definitions.