### PR TITLE
Increase timeouts for TypeScript examples

### DIFF
--- a/packages/router5-transition-path/test/main.js
+++ b/packages/router5-transition-path/test/main.js
@@ -69,6 +69,8 @@ describe('router5-transition-path', function() {
 
     describe('TypeScript definitions', function() {
         it('should compile examples against index.d.ts', function(done) {
+            this.timeout(10000)
+
             tt.compileDirectory(
                 `${__dirname}/typescript`,
                 filename => filename.match(/\.ts$/),

--- a/packages/router5/test/index.js
+++ b/packages/router5/test/index.js
@@ -33,6 +33,8 @@ describe('router5', function() {
 
 describe('TypeScript definitions', function() {
     it('should compile examples against index.d.ts', function(done) {
+        this.timeout(10000)
+
         tt.compileDirectory(
             `${__dirname}/typescript`,
             filename => filename.match(/\.ts$/),


### PR DESCRIPTION
When compiling the TypeScript examples, Travis CI sometimes takes longer
than the default Mocha timeout of 2 s. This patch increases those
timeouts to 10 s to avoid failures.

See <https://github.com/router5/router5/pull/231#issuecomment-350010732>.