### PR TITLE
Fix README.md use of routeNodeSelector

### DIFF
--- a/packages/redux-router5/README.md
+++ b/packages/redux-router5/README.md
@@ -174,7 +174,7 @@ function Root({ route }) {
     }
 }
 
-export default connect(state => routeNodeSelector(''))(Root);
+export default connect(state => routeNodeSelector('')(state))(Root);
 ```
 
 When using `routeNodeSelector` with other connect properties:


### PR DESCRIPTION
Was super confused checking my broken code against the docs for a while and was confused why you'd accept the state variable and not use it. This corrects the example to actually work and makes a little more sense too. :)