### PR TITLE
Add optional params encoders, params decoders and default params to routes

### DIFF
--- a/packages/router5/index.d.ts
+++ b/packages/router5/index.d.ts
@@ -111,6 +111,9 @@ declare module 'router5/create-router' {
         canActivate?: ActivationFnFactory
         forwardTo?: string
         children?: Route[]
+        encodeParams?(stateParams: Params): Params
+        decodeParams?(pathParams: Params): Params
+        defaultParams?: Params
     }
 
     export interface StateMeta {

--- a/packages/router5/modules/core/clone.js
+++ b/packages/router5/modules/core/clone.js
@@ -17,6 +17,7 @@ export default function withCloning(router, createRouter) {
 
         clonedRouter.useMiddleware(...router.getMiddlewareFactories())
         clonedRouter.usePlugin(...router.getPlugins())
+        clonedRouter.config = router.config
 
         const [
             canDeactivateFactories,

--- a/packages/router5/modules/core/navigation.js
+++ b/packages/router5/modules/core/navigation.js
@@ -75,7 +75,7 @@ export default function withNavigation(router) {
         const toState = router.makeState(
             route.name,
             route.params,
-            router.buildPath(name, params),
+            router.buildPath(name, route.params),
             route._meta
         )
         const sameStates = router.getState()

--- a/packages/router5/modules/core/navigation.js
+++ b/packages/router5/modules/core/navigation.js
@@ -6,7 +6,7 @@ const noop = function() {}
 export default function withNavigation(router) {
     let cancelCurrentTransition
 
-    router.forwardMap = {}
+    router.config.forwardMap = {}
     router.navigate = navigate
     router.navigateToDefault = navigateToDefault
     router.transitionToState = transitionToState
@@ -33,7 +33,7 @@ export default function withNavigation(router) {
      * @param  {String}   toRoute  The route params
      */
     function forward(fromRoute, toRoute) {
-        router.forwardMap[fromRoute] = toRoute
+        router.config.forwardMap[fromRoute] = toRoute
 
         return router
     }
@@ -47,7 +47,7 @@ export default function withNavigation(router) {
      * @return {Function}                A cancel function
      */
     function navigate(...args) {
-        const name = router.forwardMap[args[0]] || args[0]
+        const name = router.config.forwardMap[args[0]] || args[0]
         const lastArg = args[args.length - 1]
         const done = typeof lastArg === 'function' ? lastArg : noop
         const params = typeof args[1] === 'object' ? args[1] : {}

--- a/packages/router5/modules/core/utils.js
+++ b/packages/router5/modules/core/utils.js
@@ -135,15 +135,19 @@ export default function withUtils(router) {
             const decodedParams = router.config.decoders[name]
                 ? router.config.decoders[name](params)
                 : params
+            const finalParams = {
+                ...router.config.defaultParams[name],
+                ...decodedParams
+            }
             const routeName = router.config.forwardMap[name] || name
             const builtPath =
                 options.useTrailingSlash === undefined
                     ? path
-                    : router.buildPath(routeName, decodedParams)
+                    : router.buildPath(routeName, finalParams)
 
             return router.makeState(
                 routeName,
-                decodedParams,
+                finalParams,
                 builtPath,
                 _meta,
                 source

--- a/packages/router5/modules/core/utils.js
+++ b/packages/router5/modules/core/utils.js
@@ -108,7 +108,12 @@ export default function withUtils(router) {
     }
 
     function buildState(route, params) {
-        return router.rootNode.buildState(route, params)
+        const finalParams = {
+            ...router.config.defaultParams[route],
+            ...params
+        }
+
+        return router.rootNode.buildState(route, finalParams)
     }
 
     /**

--- a/packages/router5/modules/core/utils.js
+++ b/packages/router5/modules/core/utils.js
@@ -127,7 +127,7 @@ export default function withUtils(router) {
                 options.useTrailingSlash === undefined
                     ? path
                     : router.buildPath(name, params)
-            const routeName = router.forwardMap[name] || name
+            const routeName = router.config.forwardMap[name] || name
 
             return router.makeState(routeName, params, builtPath, _meta, source)
         }

--- a/packages/router5/modules/core/utils.js
+++ b/packages/router5/modules/core/utils.js
@@ -97,7 +97,11 @@ export default function withUtils(router) {
         }
 
         const { useTrailingSlash, strictQueryParams } = options
-        return router.rootNode.buildPath(route, params, {
+        const encodedParams = router.config.encoders[route]
+            ? router.config.encoders[route](params)
+            : params
+
+        return router.rootNode.buildPath(route, encodedParams, {
             trailingSlash: useTrailingSlash,
             strictQueryParams
         })
@@ -123,13 +127,22 @@ export default function withUtils(router) {
 
         if (match) {
             const { name, params, _meta } = match
+            const decodedParams = router.config.decoders[name]
+                ? router.config.decoders[name](params)
+                : params
+            const routeName = router.config.forwardMap[name] || name
             const builtPath =
                 options.useTrailingSlash === undefined
                     ? path
-                    : router.buildPath(name, params)
-            const routeName = router.config.forwardMap[name] || name
+                    : router.buildPath(routeName, decodedParams)
 
-            return router.makeState(routeName, params, builtPath, _meta, source)
+            return router.makeState(
+                routeName,
+                decodedParams,
+                builtPath,
+                _meta,
+                source
+            )
         }
 
         return null

--- a/packages/router5/modules/create-router.js
+++ b/packages/router5/modules/create-router.js
@@ -34,6 +34,7 @@ function createRouter(routes, opts = {}, deps = {}) {
     Object.keys(opts).forEach(opt => setOption(opt, opts[opt]))
 
     const router = {
+        config: {},
         rootNode,
         getOptions,
         setOption,

--- a/packages/router5/modules/create-router.js
+++ b/packages/router5/modules/create-router.js
@@ -34,7 +34,10 @@ function createRouter(routes, opts = {}, deps = {}) {
     Object.keys(opts).forEach(opt => setOption(opt, opts[opt]))
 
     const router = {
-        config: {},
+        config: {
+            decoders: {},
+            encoders: {}
+        },
         rootNode,
         getOptions,
         setOption,
@@ -110,6 +113,12 @@ function createRouter(routes, opts = {}, deps = {}) {
         if (route.canActivate) router.canActivate(route.name, route.canActivate)
 
         if (route.forwardTo) router.forward(route.name, route.forwardTo)
+
+        if (route.decodeParams)
+            router.config.decoders[route.name] = route.decodeParams
+
+        if (route.encodeParams)
+            router.config.encoders[route.name] = route.encodeParams
     }
 
     /**

--- a/packages/router5/modules/create-router.js
+++ b/packages/router5/modules/create-router.js
@@ -36,7 +36,8 @@ function createRouter(routes, opts = {}, deps = {}) {
     const router = {
         config: {
             decoders: {},
-            encoders: {}
+            encoders: {},
+            defaultParams: {}
         },
         rootNode,
         getOptions,
@@ -119,6 +120,9 @@ function createRouter(routes, opts = {}, deps = {}) {
 
         if (route.encodeParams)
             router.config.encoders[route.name] = route.encodeParams
+
+        if (route.defaultParams)
+            router.config.defaultParams[route.name] = route.defaultParams
     }
 
     /**

--- a/packages/router5/test/_create-router.js
+++ b/packages/router5/test/_create-router.js
@@ -21,6 +21,14 @@ const profileRoute = new RouteNode('profile', '/profile', [
     { name: 'user', path: '/:userId' }
 ])
 
+const routeWithDefaultParams = {
+    name: 'withDefaultParam',
+    path: '/with-default/:param',
+    defaultParams: {
+        param: 'hello'
+    }
+}
+
 const otherRoute = {
     name: 'withEncoder',
     path: '/encoded/:param1/:param2',
@@ -35,10 +43,19 @@ const otherRoute = {
 }
 
 export default function createTestRouter(options) {
-    return createRouter([usersRoute, sectionRoute, profileRoute, otherRoute], {
-        defaultRoute: 'home',
-        ...options
-    })
+    return createRouter(
+        [
+            usersRoute,
+            sectionRoute,
+            profileRoute,
+            otherRoute,
+            routeWithDefaultParams
+        ],
+        {
+            defaultRoute: 'home',
+            ...options
+        }
+    )
         .add(ordersRoute)
         .addNode('index', '/')
         .addNode('home', '/home')

--- a/packages/router5/test/_create-router.js
+++ b/packages/router5/test/_create-router.js
@@ -21,8 +21,21 @@ const profileRoute = new RouteNode('profile', '/profile', [
     { name: 'user', path: '/:userId' }
 ])
 
+const otherRoute = {
+    name: 'withEncoder',
+    path: '/encoded/:param1/:param2',
+    encodeParams: ({ one, two }) => ({
+        param1: one,
+        param2: two
+    }),
+    decodeParams: ({ param1, param2 }) => ({
+        one: param1,
+        two: param2
+    })
+}
+
 export default function createTestRouter(options) {
-    return createRouter([usersRoute, sectionRoute, profileRoute], {
+    return createRouter([usersRoute, sectionRoute, profileRoute, otherRoute], {
         defaultRoute: 'home',
         ...options
     })

--- a/packages/router5/test/core/navigation.js
+++ b/packages/router5/test/core/navigation.js
@@ -198,4 +198,12 @@ describe('core/navigation', function() {
             }
         )
     })
+
+    it('should extend default params', () => {
+        router.navigate('withDefaultParam', (err, state) => {
+            expect(state.params).to.eql({
+                param: 'hello'
+            })
+        })
+    })
 })

--- a/packages/router5/test/core/navigation.js
+++ b/packages/router5/test/core/navigation.js
@@ -187,4 +187,15 @@ describe('core/navigation', function() {
             done()
         })
     })
+
+    it('should encode params to path', done => {
+        router.navigate(
+            'withEncoder',
+            { one: 'un', two: 'deux' },
+            (err, state) => {
+                expect(state.path).to.eql('/encoded/un/deux')
+                done()
+            }
+        )
+    })
 })

--- a/packages/router5/test/core/utils.js
+++ b/packages/router5/test/core/utils.js
@@ -50,6 +50,17 @@ describe('core/utils', () => {
             expect(router.isActive('users.view', { id: 123 })).to.equal(false)
         })
 
+        it('should decode path params on match', () => {
+            expect(omitMeta(router.matchPath('/encoded/hello/123'))).to.eql({
+                name: 'withEncoder',
+                params: {
+                    one: 'hello',
+                    two: '123'
+                },
+                path: '/encoded/hello/123'
+            })
+        })
+
         it('should match deep `/` routes', function() {
             router.setOption('useTrailingSlash', false)
             expect(omitMeta(router.matchPath('/profile'))).to.eql({

--- a/packages/router5/test/router/create-router.js
+++ b/packages/router5/test/router/create-router.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 import { spy } from 'sinon'
-import createRouter, { RouteNode } from '../../modules'
+import createRouter from '../../modules'
 
 const canActivate = () => () => true
 const routes = [


### PR DESCRIPTION
Routes can now be configured with:

- `encodeParams`: a function taking state params and returning path params
- `decodeParams`: a function taking path params and returning state params
- `defaultParams`: default state params when navigating
