### PR TITLE
Fix state ID generation to not duplicate on hydration

### DIFF
--- a/packages/router5/modules/create-router.js
+++ b/packages/router5/modules/create-router.js
@@ -186,6 +186,10 @@ function createRouter(routes, opts = {}, deps = {}) {
      */
     function setState(state) {
         routerState = state
+
+        if(state && state.meta && typeof state.meta.id === 'number'){
+            stateId = state.meta.id
+        }
     }
 
     /**

--- a/packages/router5/test/core/router-lifecycle.js
+++ b/packages/router5/test/core/router-lifecycle.js
@@ -7,7 +7,7 @@ const homeState = {
     name: 'home',
     params: {},
     path: '/home',
-    meta: { params: { home: {} } }
+    meta: { id: 1, params: { home: {} } }
 }
 
 describe('core/router-lifecycle', function() {
@@ -164,6 +164,17 @@ describe('core/router-lifecycle', function() {
             expect(state).to.eql(homeState)
             expect(router.getState()).to.eql(homeState)
             done()
+        })
+    })
+
+    it('should not reuse id when starting with provided state', function(done) {
+        router.stop()
+        expect(homeState.meta.id).to.eql(1)
+        router.start(homeState, function(err, state) {
+            router.navigate('users', function(err, state) {
+                expect(state.meta.id).to.not.eql(1)
+                done()
+            });
         })
     })
 


### PR DESCRIPTION
This PR added ID generator state restoration.

When restoring state from server rendering, the state ID after first navigation will be 1 which collide with the initial state.

TODO:

- [ ] Make sure that the test fail without the given fix
- [ ] Prettier is failing