### PR TITLE
Remove need to use listeners plugin with React + smarter route node updates

### DIFF
--- a/packages/react-router5/README.md
+++ b/packages/react-router5/README.md
@@ -44,7 +44,7 @@ const AppWithRouter = (
 )
 ```
 
-* **withRoute(BaseComponent)**: HoC injecting your router instance (from context) and the current route to the wrapped component. Any route change will trigger a re-render, and requires the use of the listeners plugin.
+* **withRoute(BaseComponent)**: HoC injecting your router instance (from context) and the current route to the wrapped component. Any route change will trigger a re-render
 * **routeNode(nodeName)(BaseComponent)**: like above, expect it only re-renders when the given route node is the transition node. When using `routeNode` components, make sure to key the ones which can render the same components but with different route params.
 
 ```javascript

--- a/packages/react-router5/modules/RouteProvider.js
+++ b/packages/react-router5/modules/RouteProvider.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import transitionPath from 'router5-transition-path'
-import { ifNot } from './utils'
+import { shouldUpdateNode } from 'router5-transition-path'
 
 const emptyCreateContext = () => ({
     Provider: ({ children }) => children,
@@ -23,28 +22,20 @@ class RouteProvider extends React.PureComponent {
             previousRoute: null,
             router
         }
-
-        this.listener = this.listener.bind(this)
-    }
-
-    listener(toState, fromState) {
-        this.setState({
-            route: toState,
-            previousRoute: fromState
-        })
     }
 
     componentDidMount() {
-        ifNot(
-            this.router.hasPlugin('LISTENERS_PLUGIN'),
-            '[react-router5][RouteProvider] missing listeners plugin'
-        )
-
-        this.router.addListener(this.listener)
+        const listener = (toState, fromState) => {
+            this.setState({
+                route: toState,
+                previousRoute: fromState
+            })
+        }
+        this.unsubscribe = this.router.subscribe(listener)
     }
 
     componentWillUnmount() {
-        this.router.removeListener(this.listener)
+        this.unsubscribe()
     }
 
     getChildContext() {
@@ -73,12 +64,12 @@ class RouteNode extends React.Component {
     }
 
     renderOnRouteNodeChange(routeContext) {
-        const { intersection } = transitionPath(
+        const shouldUpdate = shouldUpdateNode(this.props.nodeName)(
             routeContext.route,
             routeContext.previousRoute
         )
 
-        if (!this.memoizedResult || intersection === this.props.nodeName) {
+        if (!this.memoizedResult || shouldUpdate) {
             this.memoizedResult = this.props.children(routeContext)
         }
 

--- a/packages/react-router5/modules/withRoute.js
+++ b/packages/react-router5/modules/withRoute.js
@@ -1,5 +1,5 @@
 import { Component, createElement } from 'react'
-import { ifNot, getDisplayName } from './utils'
+import { getDisplayName } from './utils'
 import PropTypes from 'prop-types'
 
 function withRoute(BaseComponent) {
@@ -11,39 +11,20 @@ function withRoute(BaseComponent) {
                 previousRoute: null,
                 route: this.router.getState()
             }
-            this.listener = this.listener.bind(this)
         }
 
         componentDidMount() {
-            ifNot(
-                this.router.hasPlugin('LISTENERS_PLUGIN'),
-                '[react-router5][withRoute] missing listeners plugin'
-            )
-
-            this.listener = (toState, fromState) =>
-                this.setState({ previousRoute: fromState, route: toState })
-            this.router.addListener(this.listener)
+            const listener = ({ route, previousRoute }) => {
+                this.setState({ route, previousRoute })
+            }
+            this.unsubscribe = this.router.subscribe(listener)
         }
 
         componentWillUnmount() {
-            this.router.removeListener(this.listener)
-        }
-
-        listener(toState, fromState) {
-            this.setState({
-                previousRoute: fromState,
-                route: toState
-            })
+            this.unsubscribe()
         }
 
         render() {
-            ifNot(
-                !this.props.router &&
-                    !this.props.route &&
-                    !this.props.previousRoute,
-                '[react-router5] prop names `router`, `route` and `previousRoute` are reserved.'
-            )
-
             return createElement(BaseComponent, {
                 ...this.props,
                 ...this.state,

--- a/packages/react-router5/test/main.js
+++ b/packages/react-router5/test/main.js
@@ -22,14 +22,6 @@ describe('withRoute hoc', () => {
         router = createTestRouter()
     })
 
-    it('should throw an error if router5-plugin-listeners plugin is not used', () => {
-        const renderTree = () =>
-            renderWithRouter(router)(withRoute(() => <div />))
-        expect(renderTree).to.throw(
-            '[react-router5][withRoute] missing listeners plugin'
-        )
-    })
-
     it('should inject the router in the wrapped component props', () => {
         const ChildSpy = spy(FnChild)
         router.usePlugin(listenersPlugin())
@@ -48,13 +40,6 @@ describe('routeNode hoc', () => {
 
     before(() => {
         router = createTestRouter()
-    })
-
-    it('should throw an error if router5-plugin-listeners plugin is not used', () => {
-        const renderTree = () => renderWithRouter(router)(routeNode('')(Child))
-        expect(renderTree).to.throw(
-            '[react-router5][routeNode] missing listeners plugin'
-        )
     })
 
     it('should inject the router in the wrapped component props', () => {


### PR DESCRIPTION
- No longer need to use `listenersPlugin` with React
- Route node updates are smarter and safer