### PR TITLE
Replace addEventListeners calls with addEventListener

### DIFF
--- a/dist/router5BrowserPlugin.js
+++ b/dist/router5BrowserPlugin.js
@@ -66,7 +66,7 @@
         window.addEventListener('popstate', fn);
 
         if (!supportsPopStateOnHashChange()) {
-            window.addEventListeners('hashchange', fn);
+            window.addEventListener('hashchange', fn);
         }
     };
 

--- a/packages/docs/server/public/app.js
+++ b/packages/docs/server/public/app.js
@@ -5802,7 +5802,7 @@ and limitations under the License.
                       },
                       addPopstateListener: function(e) {
                           window.addEventListener('popstate', e),
-                              a() || window.addEventListeners('hashchange', e)
+                              a() || window.addEventListener('hashchange', e)
                       },
                       removePopstateListener: function(e) {
                           window.removeEventListener('popstate', e),

--- a/packages/router5/modules/plugins/browser/browser.js
+++ b/packages/router5/modules/plugins/browser/browser.js
@@ -29,7 +29,7 @@ const addPopstateListener = fn => {
     window.addEventListener('popstate', fn)
 
     if (!supportsPopStateOnHashChange()) {
-        window.addEventListeners('hashchange', fn)
+        window.addEventListener('hashchange', fn)
     }
 }
 


### PR DESCRIPTION
I think this is a typo as there is no ` window.addEventListeners` function. That's why router5 stopped working in IE11 on our current projects.