### PR TITLE
fix: types/redux-router5/reduxPlulgin definition

### DIFF
--- a/packages/redux-router5/index.d.ts
+++ b/packages/redux-router5/index.d.ts
@@ -13,7 +13,7 @@ declare module 'redux-router5' {
 
     export const router5Reducer: Reducer<RouterState>
 
-    export function reduxPlugin<TState extends { router: RouterState }>(
+    export function reduxPlugin<TState extends { router: RouterState, type: TState }>(
         dispatch: Dispatch<TState>
     ): PluginFactory
 


### PR DESCRIPTION
looks like it's doing a type extends, that's not working (maybe some changes in typescript?), this way it makes sure that the type is there.

please review as I'm not too sure about this.