### PR TITLE
Ensure activeClassName has higher specificity

### DIFF
--- a/packages/react-router5/modules/BaseLink.js
+++ b/packages/react-router5/modules/BaseLink.js
@@ -91,8 +91,8 @@ class BaseLink extends Component {
 
         const active = this.isActive()
         const href = this.buildUrl(routeName, routeParams)
-        const linkclassName = (className ? className.split(' ') : [])
-            .concat(active ? [activeClassName] : [])
+        const linkclassName = (active ? [activeClassName] : [])
+            .concat(className ? className.split(' ') : [])
             .join(' ')
 
         return React.createElement(


### PR DESCRIPTION
Avoids need for `!important` to override base styles when selectors have equal specificity