### PR TITLE
Add `ignoreQueryParams` prop in link component

### DIFF
--- a/packages/react-router5/modules/BaseLink.js
+++ b/packages/react-router5/modules/BaseLink.js
@@ -32,7 +32,8 @@ class BaseLink extends Component {
         return this.router.isActive(
             this.props.routeName,
             this.props.routeParams,
-            this.props.activeStrict
+            this.props.activeStrict,
+            this.props.ignoreQueryParams
         )
     }
 
@@ -78,6 +79,7 @@ class BaseLink extends Component {
             className,
             activeClassName,
             activeStrict,
+            ignoreQueryParams,
             route,
             previousRoute,
             router,
@@ -118,6 +120,7 @@ BaseLink.propTypes = {
     routeOptions: PropTypes.object,
     activeClassName: PropTypes.string,
     activeStrict: PropTypes.bool,
+    ignoreQueryParams: PropTypes.bool,
     onClick: PropTypes.func,
     onMouseOver: PropTypes.func,
     successCallback: PropTypes.func,
@@ -127,6 +130,7 @@ BaseLink.propTypes = {
 BaseLink.defaultProps = {
     activeClassName: 'active',
     activeStrict: false,
+    ignoreQueryParams: true,
     routeParams: {},
     routeOptions: {}
 }

--- a/packages/react-router5/modules/BaseLink.js
+++ b/packages/react-router5/modules/BaseLink.js
@@ -9,7 +9,7 @@ class BaseLink extends Component {
 
         if (!this.router.hasPlugin('BROWSER_PLUGIN')) {
             console.error(
-                '[react-router5][BaseLink] missing browser plugin, href might be build incorrectly'
+                '[react-router5][BaseLink] missing browser plugin, href might be built incorrectly'
             )
         }
 


### PR DESCRIPTION
This PR adds the `ignoreQueryParams` prop to BaseLink to make use of router5's ability to either check or ignore query params when establishing whether a route is active.

It will help with selectively applying the `activeClassName` prop to the link in cases when routes differ only in their their query parameters.

Addresses https://github.com/router5/router5/issues/322