### PR TITLE
feat: update RouterState

### DIFF
--- a/packages/redux-router5/index.d.ts
+++ b/packages/redux-router5/index.d.ts
@@ -5,10 +5,10 @@ declare module 'redux-router5' {
     export function router5Middleware(router: Router): Middleware
 
     export interface RouterState {
-        route: State | null
-        previousRoute: State | null
-        transitionRoute: State | null
-        transitionError: any | null
+        route?: State
+        previousRoute?: State
+        transitionRoute?: State
+        transitionError?: any
     }
 
     export const router5Reducer: Reducer<RouterState>


### PR DESCRIPTION
I saw that it also can be null, I was thinking, we can just declare them optional, so user don't have to pass in all keys. Or did I miss something? Or does it explicitly have to be null?