### PR TITLE
Improve performance of adding routes

### DIFF
--- a/packages/router5/package.json
+++ b/packages/router5/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://router5.js.org",
   "dependencies": {
-    "route-node": "3.3.0",
+    "route-node": "3.4.0",
     "router5-transition-path": "^5.3.0",
     "symbol-observable": "1.2.0"
   },

--- a/packages/router5/yarn.lock
+++ b/packages/router5/yarn.lock
@@ -8,16 +8,12 @@ path-parser@4.2.0:
   dependencies:
     search-params "2.1.3"
 
-route-node@3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/route-node/-/route-node-3.3.0.tgz#df3e4436ae0cc0c3620d43cc28ee9ca098301cbb"
+route-node@3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/route-node/-/route-node-3.4.0.tgz#6fc581b86d824d1dbe2de4f7dfc2654b10901e4d"
   dependencies:
     path-parser "4.2.0"
     search-params "2.1.3"
-
-router5-transition-path@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/router5-transition-path/-/router5-transition-path-5.3.0.tgz#113f7e09dffee5e22c7275c20fe25969c0bc1599"
 
 search-params@2.1.3:
   version "2.1.3"


### PR DESCRIPTION
Closes #328 

It has been noticed that with a large number of sibling routes (~200 or more), performance deteriorates rapidly.