### PR TITLE
Check if state has meta params before extracting segment params

### DIFF
--- a/packages/router5-transition-path/modules/transitionPath.js
+++ b/packages/router5-transition-path/modules/transitionPath.js
@@ -13,7 +13,7 @@ function hasMetaParams(state) {
 }
 
 function extractSegmentParams(name, state) {
-    if (!exists(state.meta.params[name])) return {}
+    if (!hasMetaParams(state) || !exists(state.meta.params[name])) return {}
 
     return Object.keys(state.meta.params[name]).reduce((params, p) => {
         params[p] = state.params[p]


### PR DESCRIPTION
In the webapp I'm working on, I've been facing a situation with `state.meta.params` as `undefined` in the method `extractSegmentParams`.

In order to avoid an error to be thrown and for safety, it would be better to check that `state.meta.params` is defined before trying to extract segment params.

Thanks for the review!