### PR TITLE
Fix state set in router.replaceHistoryState

### DIFF
--- a/packages/router5/modules/plugins/browser/index.js
+++ b/packages/router5/modules/plugins/browser/index.js
@@ -38,7 +38,13 @@ function browserPluginFactory(opts = {}, browser = safeBrowser) {
         }
 
         router.replaceHistoryState = function(name, params = {}) {
-            const state = router.buildState(name, params)
+            const route = router.buildState(name, params)
+            const state = router.makeState(
+                route.name,
+                route.params,
+                router.buildPath(route.name, route.params),
+                { params: route.meta }
+            )
             const url = router.buildUrl(name, params)
             router.lastKnownState = state
             browser.replaceState(state, '', url)


### PR DESCRIPTION
In `router.replaceHistoryState`, the state is not generated the right way. It should be generated the same way as in `router.navigate`.

Right now, in `router.navigate` :

```js
const route = router.buildState(name, params)
const toState = router.makeState(
    route.name,
    route.params,
    router.buildPath(route.name, route.params),
    { params: route.meta, options: opts }
)
```

Right now, in `router.replaceHistoryState` :

```js
const state = router.buildState(name, params)
```

As you can see the state is not generated the same way.

This lead to a different state format that I've been highlighting in the following example :
https://stackblitz.com/edit/react-router5-nsflq1

* Go to the compose page
* Click on the button "router.replaceHistoryState"
* Watch the console

As you can see `router.lastKnownState.meta` format is wrong. The key `compose` should be in `meta.params` and not direcly in `meta`.

Thanks for the review !