### PR TITLE
upgrade prop-types in react-router5 to v15.6

### DIFF
--- a/packages/react-router5/package.json
+++ b/packages/react-router5/package.json
@@ -28,7 +28,7 @@
     "router5": ">= 6.1.0 < 7.0.0"
   },
   "dependencies": {
-    "prop-types": "~15.5.10",
+    "prop-types": "^15.6.0",
     "router5-transition-path": "^5.3.1"
   },
   "typings": "./index.d.ts",

--- a/packages/react-router5/yarn.lock
+++ b/packages/react-router5/yarn.lock
@@ -73,18 +73,6 @@ fbjs@^0.8.16:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
-fbjs@^0.8.9:
-  version "0.8.12"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
-  dependencies:
-    core-js "^1.0.0"
-    isomorphic-fetch "^2.1.1"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^0.7.9"
-
 foreach@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
@@ -190,19 +178,11 @@ promise@^7.1.1:
     asap "~2.0.3"
 
 prop-types@^15.6.0:
-  version "15.6.1"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   dependencies:
-    fbjs "^0.8.16"
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
-
-prop-types@~15.5.10:
-  version "15.5.10"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.3.1"
 
 react-is@^16.3.1:
   version "16.3.1"
@@ -226,9 +206,9 @@ react-test-renderer@^16.0.0-0:
     prop-types "^15.6.0"
     react-is "^16.3.1"
 
-router5-transition-path@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/router5-transition-path/-/router5-transition-path-5.3.0.tgz#113f7e09dffee5e22c7275c20fe25969c0bc1599"
+router5-transition-path@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/router5-transition-path/-/router5-transition-path-5.3.1.tgz#1ab4b707f4cf14460e2cfc0fc38642b34f1d7688"
 
 setimmediate@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
upgrade prop-types in react-router5 to v15.6
* bundle size is reduced because it's the same version used in `react` and `react-dom`
* MIT license (15.5 was BSD + Patent)