### PR TITLE
Add a withRouter component

### DIFF
--- a/packages/react-router5/modules/index.js
+++ b/packages/react-router5/modules/index.js
@@ -2,6 +2,7 @@ import BaseLink from './BaseLink'
 import routeNode from './routeNode'
 import RouterProvider from './RouterProvider'
 import withRoute from './withRoute'
+import withRouter from './withRouter'
 import { RouteProvider, Route, RouteNode } from './RouteProvider'
 
 const Link = withRoute(BaseLink)
@@ -11,6 +12,7 @@ export {
     routeNode,
     RouterProvider,
     withRoute,
+    withRouter,
     Link,
     RouteProvider,
     Route,

--- a/packages/react-router5/modules/withRouter.js
+++ b/packages/react-router5/modules/withRouter.js
@@ -1,0 +1,30 @@
+import { Component, createElement } from 'react'
+import { getDisplayName } from './utils'
+import PropTypes from 'prop-types'
+
+function withRouter(BaseComponent) {
+    class ComponentWithRouter extends Component {
+        constructor(props, context) {
+            super(props, context)
+            this.router = context.router
+        }
+
+        render() {
+            return createElement(BaseComponent, {
+                ...this.props,
+                router: this.router
+            })
+        }
+    }
+
+    ComponentWithRouter.contextTypes = {
+        router: PropTypes.object.isRequired
+    }
+
+    ComponentWithRouter.displayerName =
+        'WithRouter[' + getDisplayName(BaseComponent) + ']'
+
+    return ComponentWithRouter
+}
+
+export default withRouter

--- a/packages/react-router5/test/main.js
+++ b/packages/react-router5/test/main.js
@@ -4,6 +4,7 @@ import { Child, createTestRouter, FnChild, renderWithRouter } from './utils'
 import {
     RouterProvider,
     withRoute,
+    withRouter,
     routeNode,
     BaseLink,
     Link
@@ -31,6 +32,25 @@ describe('withRoute hoc', () => {
             router,
             route: null,
             previousRoute: null
+        })
+    })
+})
+
+describe('withRouter hoc', () => {
+    let router
+
+    before(() => {
+        router = createTestRouter()
+    })
+
+    it('should inject the router on the wrapped component props', () => {
+        const ChildSpy = spy(FnChild)
+        router.usePlugin(listenersPlugin())
+
+        renderWithRouter(router)(withRouter(ChildSpy))
+
+        expect(ChildSpy).to.have.been.calledWith({
+            router
         })
     })
 })


### PR DESCRIPTION
I can be very handy to retrieve the router from the context in some cases (pass it to other librairies, non-react code...).

**Example:**

```javascript
class AppComponent extends React.Component {
  componentDidMount() {
    initMyOldJqueryPlugin(/* I would like the instance of the router here to let the old code navigate */)
  }
}
```

For now, I see 2 options to do this:
  - Use the router as a single instance (singleton)
  - Use the withRoute hoc to inject the router 

Use the router as a singleton is not really liked by everyone for some reasons

Up to now, I was using `withRoute` ton inject the router, it was working fine, but I realised it was updating all my component tree.

`withRouter` introduce a new way to retrieve the router anywhere from the component tree while beeing sure the component won't rerender on route change