### PR TITLE
Fixed incorrect path to TS types in react-router5/package.json

### DIFF
--- a/packages/react-router5/package.json
+++ b/packages/react-router5/package.json
@@ -35,7 +35,7 @@
     "prop-types": "~15.6.2",
     "router5-transition-path": "^7.0.0"
   },
-  "typings": "./index.d.ts",
+  "typings": "./types/index.d.ts",
   "scripts": {
     "test": "jest"
   }


### PR DESCRIPTION
Without this fix VS Code tells user that the `react-router5` has no typings.