### PR TITLE
Base link

### DIFF
--- a/packages/react-router5/README.md
+++ b/packages/react-router5/README.md
@@ -45,7 +45,8 @@ You can connect your components using three different methods:
 
 ## Link components
 
--   **Link**: a component to render hyperlinks. For a full list of supported props, check the source! `Link` is `withRoute` and `Link` composed together
+-   **BaseLink**: a component to render hyperlinks. For a full list of supported props, check the source!
+-   **Link**: `Link` is `withRoute` and `BaseLink` composed together
 -   **ConnectedLink**: same as `Link`, except it re-renders on a route changes.
 
 ```javascript

--- a/packages/react-router5/README.md
+++ b/packages/react-router5/README.md
@@ -46,7 +46,7 @@ You can connect your components using three different methods:
 ## Link components
 
 -   **BaseLink**: a component to render hyperlinks. For a full list of supported props, check the source!
--   **Link**: `Link` is `withRoute` and `BaseLink` composed together
+-   **Link**: `Link` is `withRouter` and `BaseLink` composed together
 -   **ConnectedLink**: same as `Link`, except it re-renders on a route changes.
 
 ```javascript

--- a/packages/react-router5/modules/BaseLink.ts
+++ b/packages/react-router5/modules/BaseLink.ts
@@ -16,7 +16,7 @@ export interface BaseLinkProps extends HTMLAttributes<HTMLAnchorElement> {
     target?: string
     route?: State
     previousRoute?: State
-    router?: Router
+    router: Router
 }
 
 export interface BaseLinkState {

--- a/packages/react-router5/modules/hocs/withRouter.tsx
+++ b/packages/react-router5/modules/hocs/withRouter.tsx
@@ -4,7 +4,7 @@ import { routerContext } from '../context'
 
 function withRouter<P>(
     BaseComponent: ComponentType<P & { router: Router }>
-): SFC<P> {
+): SFC<Exclude<P, 'router'>> {
     return function WithRouter(props) {
         return (
             <routerContext.Consumer>

--- a/packages/react-router5/modules/index.ts
+++ b/packages/react-router5/modules/index.ts
@@ -18,6 +18,7 @@ const Route = routeContext.Consumer
 
 export {
     RouterProvider,
+    BaseLink,
     ConnectedLink,
     Link,
     // HoC


### PR DESCRIPTION
Fixes https://github.com/router5/router5/issues/392

Exported BaseLink + updated withRouter typings to exclude `router` from props

PS: I am not able to build the changes localy (including current master branch). Typescript passes, but all the steps after - prettier, es-lint, ... - are failing