### PR TITLE
Fix use route node

### DIFF
--- a/packages/react-router5/modules/__tests__/helpers/index.tsx
+++ b/packages/react-router5/modules/__tests__/helpers/index.tsx
@@ -18,6 +18,24 @@ export const createTestRouter = () => {
     return router
 }
 
+export const createTestRouterWithADefaultRoute = () => {
+    const router = createRouter(
+        [
+            {
+                name: 'test',
+                path: '/'
+            }
+        ],
+        { defaultRoute: 'test' }
+    )
+    router.usePlugin(
+        browserPlugin({
+            useHash: true
+        })
+    )
+    return router
+}
+
 export const renderWithRouter = router => BaseComponent =>
     mount(
         <RouterProvider router={router}>

--- a/packages/react-router5/modules/__tests__/hocs.ts
+++ b/packages/react-router5/modules/__tests__/hocs.ts
@@ -1,4 +1,9 @@
-import { createTestRouter, FnChild, renderWithRouter } from './helpers'
+import {
+    createTestRouter,
+    FnChild,
+    renderWithRouter,
+    createTestRouterWithADefaultRoute
+} from './helpers'
 import { withRoute, withRouter, routeNode } from '..'
 import { configure } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
@@ -52,9 +57,11 @@ describe('withRouter hoc', () => {
 
 describe('routeNode hoc', () => {
     let router
+    let routerWithADefaultRoute
 
     beforeAll(() => {
         router = createTestRouter()
+        routerWithADefaultRoute = createTestRouterWithADefaultRoute()
     })
 
     it('should inject the router in the wrapped component props', () => {
@@ -69,5 +76,17 @@ describe('routeNode hoc', () => {
             },
             {}
         )
+    })
+
+    it('Route should not be null with a default route and the router started', () => {
+        const ChildSpy = jest.fn(FnChild)
+
+        const BaseComponent = routeNode('')(ChildSpy)
+
+        routerWithADefaultRoute.start(() => {
+            renderWithRouter(routerWithADefaultRoute)(BaseComponent)
+            /* first call, first argument */
+            expect(ChildSpy.mock.calls[0][0].route.name).toBe('test')
+        })
     })
 })

--- a/packages/react-router5/modules/__tests__/hooks.ts
+++ b/packages/react-router5/modules/__tests__/hooks.ts
@@ -1,4 +1,9 @@
-import { createTestRouter, FnChild, renderWithRouter } from './helpers'
+import {
+    createTestRouter,
+    createTestRouterWithADefaultRoute,
+    FnChild,
+    renderWithRouter
+} from './helpers'
 import { useRoute, useRouter, useRouteNode } from '..'
 import { configure } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
@@ -50,12 +55,14 @@ describe('useRouter hook', () => {
 
 describe('useRouteNode hook', () => {
     let router
+    let routerWithADefaultRoute
 
     beforeAll(() => {
         router = createTestRouter()
+        routerWithADefaultRoute = createTestRouterWithADefaultRoute()
     })
 
-    it('should inject the router in the wrapped component props', () => {
+    it('should return the router', () => {
         const ChildSpy = jest.fn(FnChild)
 
         renderWithRouter(router)(() => ChildSpy(useRouteNode('')))
@@ -63,6 +70,18 @@ describe('useRouteNode hook', () => {
             router,
             route: null,
             previousRoute: null
+        })
+    })
+
+    it('should not return a null route with a default route and the router started', () => {
+        const ChildSpy = jest.fn(FnChild)
+
+        const BaseComponent = () => ChildSpy(useRouteNode(''))
+
+        routerWithADefaultRoute.start(() => {
+            renderWithRouter(routerWithADefaultRoute)(BaseComponent)
+            /* first call, first argument */
+            expect(ChildSpy.mock.calls[0][0].route.name).toBe('test')
         })
     })
 })

--- a/packages/react-router5/modules/hocs/routeNode.tsx
+++ b/packages/react-router5/modules/hocs/routeNode.tsx
@@ -4,7 +4,7 @@ import RouteNode from '../render/RouteNode'
 
 function routeNode<P>(nodeName: string) {
     return function(BaseComponent: ComponentType<P & RouteContext>): SFC<P> {
-        function RouteNodeWrapper(props) {
+        function RouteNodeWrapper(props: P) {
             return (
                 <RouteNode nodeName={nodeName}>
                     {routeContext => (

--- a/packages/react-router5/modules/hooks/useRouteNode.ts
+++ b/packages/react-router5/modules/hooks/useRouteNode.ts
@@ -7,10 +7,11 @@ export type UnsubscribeFn = () => void
 
 export default function useRouter(nodeName: string): RouteContext {
     const router = useContext(routerContext)
-    const [state, setState] = useState({
+
+    const [state, setState] = useState(() => ({
         previousRoute: null,
-        route: null
-    })
+        route: router.getState()
+    }))
 
     useEffect(
         () =>


### PR DESCRIPTION
Should fix #395 

Add tests for:
  - `useRouteNode`
  - `routeNode()`

Initialize state with `router.getState()` (the same as the hoc version)