### PR TITLE
Encode only path and leave hash intact to avoid double encoding

### DIFF
--- a/packages/router5-plugin-browser/modules/browser.ts
+++ b/packages/router5-plugin-browser/modules/browser.ts
@@ -41,7 +41,7 @@ const getLocation = opts => {
         : window.location.pathname.replace(new RegExp('^' + opts.base), '')
 
     // Fix issue with browsers that don't URL encode characters (Edge)
-    const correctedPath = safelyEncodePath(path)
+    const correctedPath = opts.useHash ? path : safelyEncodePath(path)
 
     return (correctedPath || '/') + window.location.search
 }


### PR DESCRIPTION
This is maybe regression of #384 and aiming to  fix `URL is over encoded` #427 issue and probably `Double encoding or no encoding` #404.

Basically `encodeURI(decodeURI(path))` works only for `window.location.pathname` and fails for `window.location.hash` or `window.location.search` containing query strings, i.e `?name=ferret&color=purple`, so make sure apply it only for `pathname`.