### PR TITLE
Don't clobber the location search when using hash navigation

### DIFF
--- a/packages/router5-plugin-browser/modules/index.ts
+++ b/packages/router5-plugin-browser/modules/index.ts
@@ -43,7 +43,7 @@ function browserPluginFactory(
 
         router.buildUrl = (route, params) => {
             const base = options.base || ''
-            const prefix = options.useHash ? `#${options.hashPrefix}` : ''
+            const prefix = options.useHash ? `${window.location.search}#${options.hashPrefix}` : ''
             const path = router.buildPath(route, params)
 
             if (path === null) return null


### PR DESCRIPTION
I have a existing app that I am integrating a router5 based app into

The app needs to run using hash navigation since the server cant be modified to handle html5 style URLs

The app currently requires a url query parameter for security reasons.

When using this plugin the query parameter is clobbeder

This patch retains it

ie..

```
/context/?token=DSFADSF
```

at startup redirects to 

```
/context/#/
```

where as it should not clobber the search and use :

```
/context/?token=DSFADSF#/
```