### PR TITLE
docs: improve withRouter hoc types

### DIFF
--- a/packages/react-router5/modules/hocs/withRouter.tsx
+++ b/packages/react-router5/modules/hocs/withRouter.tsx
@@ -1,11 +1,11 @@
-import React, { SFC, ComponentType } from 'react'
+import React, { ComponentType } from 'react'
 import { Router } from 'router5'
 import { routerContext } from '../context'
 
 function withRouter<P>(
     BaseComponent: ComponentType<P & { router: Router }>
-): SFC<Exclude<P, 'router'>> {
-    return function WithRouter(props) {
+): ComponentType<Omit<P, 'router'>> {
+    return function WithRouter(props: P) {
         return (
             <routerContext.Consumer>
                 {router => <BaseComponent {...props} router={router} />}


### PR DESCRIPTION
react-router5 - improve withRouter hoc types

- removed deprecated SFC
- It seems we should use Omit and not Exclude to remove the route prop from the returned component

cc @FranciscoMSM @davidgomes