### PR TITLE
Delete duplicate sentence in loading-async-data.md

### DIFF
--- a/docs/advanced/loading-async-data.md
+++ b/docs/advanced/loading-async-data.md
@@ -83,7 +83,7 @@ In the case you don't want a route transition to wait for data to be loaded, you
 
 > Using a state container like redux gives you a lot more flexibility with your routing strategy.
 
-Using a state container like redux gives you a lot more flexibility with your routing strategy. Because all data ends up in the same bucket that your components can listen to, data loading doesn't need to block route transitions. The only thing it needs is a reference to your store so actions can be dispatched. As a result, your view can represent with greater details the state of your application: for example your UI can be a lot more explicit about displaying loading feedback. Not blocking route transitions also means immediate URL updates \(history\), making your app feel more responsive.
+Because all data ends up in the same bucket that your components can listen to, data loading doesn't need to block route transitions. The only thing it needs is a reference to your store so actions can be dispatched. As a result, your view can represent with greater details the state of your application: for example your UI can be a lot more explicit about displaying loading feedback. Not blocking route transitions also means immediate URL updates \(history\), making your app feel more responsive.
 
 The following example assumes the use a redux store configured with a `redux-thunk` middleware.
 


### PR DESCRIPTION
The same sentence appears twice in a row in this document.
On the first occasion it is used in a block spaced paragraph, directly thereafter it is used in a standard paragraph.
I assume that this is not intetional and suggest to remove the one in the standard paragraph.