### PR TITLE
router5 and react-router5 types corrections.

### DIFF
--- a/packages/react-router5/modules/RouterProvider.tsx
+++ b/packages/react-router5/modules/RouterProvider.tsx
@@ -1,14 +1,19 @@
 import React, { ReactNode } from 'react'
 import { UnsubscribeFn, RouteState } from './types'
 import { Router } from 'router5'
+import { DefaultDependencies } from 'router5/dist/types/router'
 import { routerContext, routeContext } from './context'
 
-export interface RouteProviderProps {
-    router: Router
+export interface RouteProviderProps<
+    Dependencies extends DefaultDependencies = DefaultDependencies
+> {
+    router: Router<Dependencies>
     children: ReactNode
 }
 
-class RouterProvider extends React.PureComponent<RouteProviderProps> {
+class RouterProvider<
+    Dependencies extends DefaultDependencies = DefaultDependencies
+> extends React.PureComponent<RouteProviderProps<Dependencies>> {
     private mounted: boolean
     private routeState: RouteState
     private unsubscribe: UnsubscribeFn

--- a/packages/router5/modules/index.ts
+++ b/packages/router5/modules/index.ts
@@ -17,7 +17,8 @@ export {
     SubscribeState,
     SubscribeFn,
     Listener,
-    Subscription
+    Subscription,
+    DefaultDependencies
 } from './types/router'
 export { State, StateMeta, NavigationOptions } from './types/base'
 

--- a/packages/router5/modules/types/router.ts
+++ b/packages/router5/modules/types/router.ts
@@ -195,11 +195,11 @@ export interface Plugin {
     teardown?(): void
 }
 
-export type Middleware = (
+export type Middleware<EnhancedState extends State = State> = (
     toState: State,
     fromState: State,
     done: DoneFn
-) => boolean | Promise<any> | void
+) => boolean | Promise<any> | EnhancedState | void
 
 export type MiddlewareFactory<
     Dependencies extends DefaultDependencies = DefaultDependencies


### PR DESCRIPTION
1. [router5] Middleware function, it's possible to return `State` from it.
2. [router5] Added export of `DefaultDependencies`, instead of importing it from `router5/dist/types/router`
3. [react-router5] RouterProvider should be able to accept `Route` with additional dependencies

If `2` will be added, it will be possible to alter `3` a bit in further commits and import `DefaultDependencies` from router5, instead of as i done it right now (from `router5/dist/types/router`)