### PR TITLE
Re-export MiddlewareFactory type

### DIFF
--- a/packages/router5/modules/index.ts
+++ b/packages/router5/modules/index.ts
@@ -14,6 +14,7 @@ export {
     Plugin,
     PluginFactory,
     Middleware,
+    MiddlewareFactory,
     SubscribeState,
     SubscribeFn,
     Listener,


### PR DESCRIPTION
I don't see why PluginFactory would be exported but not MiddlewareFactory. It makes it way easier to type custom middlewares