### PR TITLE
Api Ref update: Add return for matchPath and ref for lastKnownState

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -202,7 +202,7 @@ router.buildPath(route, params)
 
 ### matchPath
 
-Attempt to match a path
+Attempt to match a path, if the path is in the Router State it will return the State, otherwise returns `null`
 
 ```javascript
 router.matchPath(path, [source])
@@ -275,3 +275,10 @@ Replace state in history and silently update your router instance state. Use if 
 router.replaceHistoryState(name, params)
 ```
 
+### lastKnownState
+
+Returns the last known Router state if the history has been replaced, otherwise returns `undefined`
+
+```javascript
+router.lastKnownState
+```

--- a/packages/router5/modules/types/base.ts
+++ b/packages/router5/modules/types/base.ts
@@ -14,6 +14,8 @@ export type DoneFn = (err?: any, state?: State) => void
 
 export type CancelFn = () => void
 
+export type CallbackFn = (n: any) => any
+
 export interface StateMeta {
     id: number
     params: Params

--- a/packages/router5/modules/types/router.ts
+++ b/packages/router5/modules/types/router.ts
@@ -13,7 +13,8 @@ import {
     DoneFn,
     NavigationOptions,
     Unsubscribe,
-    CancelFn
+    CancelFn,
+    CallbackFn
 } from './base'
 
 export interface Route<
@@ -155,9 +156,9 @@ export interface Router<
         ) => any
     ): any
 
-    invokeEventListeners: (eventName, ...args) => void
-    removeEventListener: (eventName, cb) => void
-    addEventListener: (eventName, cb) => Unsubscribe
+    invokeEventListeners: (eventName: string, ...args: any[]) => void
+    removeEventListener: (eventName: string, callback: CallbackFn) => void
+    addEventListener: (eventName: string, callback: CallbackFn) => Unsubscribe
 
     cancel(): Router<Dependencies>
     forward(fromRoute: string, toRoute: string): Router<Dependencies>


### PR DESCRIPTION
Was using `matchPath` and realised the API docs don't say what will be returned from it as I was expecting a boolean.
Then got carried away after seeing the types for the browser plugin and `lastKnownState` was not referenced, there's quite a few missing references, i'm happy to add more at some point so the docs are clearer.

Then i got further carried away seeing there was missing types on some function params