### PR TITLE
add params to navigation NOT_FOUND error object

### DIFF
--- a/packages/router5/modules/core/navigation.ts
+++ b/packages/router5/modules/core/navigation.ts
@@ -58,7 +58,13 @@ export default function withNavigation<Dependencies>(
         const route = router.buildState(name, params)
 
         if (!route) {
-            const err = { code: errorCodes.ROUTE_NOT_FOUND }
+            const err = { 
+                code: errorCodes.ROUTE_NOT_FOUND, 
+                route: {
+                    name,
+                    params
+                } 
+            }
             done(err)
             router.invokeEventListeners(
                 constants.TRANSITION_ERROR,


### PR DESCRIPTION
It is useful to know which route causes an issue for lazy routing or logging